### PR TITLE
Feature to upload new image into the database

### DIFF
--- a/.github/workflows/ruff_unittest.yml
+++ b/.github/workflows/ruff_unittest.yml
@@ -1,0 +1,40 @@
+name: CI Pipeline
+
+# Trigger the workflow on both push and pull requests
+on: [push, pull_request]
+
+jobs:
+  # Ruff linter job
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Ruff
+        uses: chartboost/ruff-action@v1
+
+  # Unit test job
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.12'  
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: |
+          python -m unittest discover -s test  
+
+      

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore Python bytecode
+*.pyc
+*.pyo
+*.pyd
+
+# Ignore __pycache__ directories
+__pycache__/
+
+# Ignore virtual environment folders
+venv/
+.env/

--- a/src/facematch/bulk_upload.py
+++ b/src/facematch/bulk_upload.py
@@ -2,8 +2,8 @@ import os
 import csv
 import json 
 
-def upload_embedding_to_database(data):
-    csv_file = "data/embeddings.csv"
+def upload_embedding_to_database(data, database_filepath):
+    csv_file = database_filepath
     os.makedirs(os.path.dirname(csv_file), exist_ok=True)
 
     with open(csv_file, mode='w', newline='') as file:

--- a/src/facematch/bulk_upload.py
+++ b/src/facematch/bulk_upload.py
@@ -1,0 +1,17 @@
+import os 
+import csv
+import json 
+
+def upload_embedding_to_database(data):
+    csv_file = "data/embeddings.csv"
+    os.makedirs(os.path.dirname(csv_file), exist_ok=True)
+
+    with open(csv_file, mode='w', newline='') as file:
+        # Create a CSV writer object
+        writer = csv.DictWriter(file, fieldnames=data[0].keys())
+
+        # Write the header (column names)
+        writer.writeheader()
+
+        # Write each dictionary as a row in the CSV file
+        writer.writerows(data)

--- a/src/facematch/bulk_upload.py
+++ b/src/facematch/bulk_upload.py
@@ -1,6 +1,5 @@
 import os 
 import csv
-import json 
 
 def upload_embedding_to_database(data, database_filepath):
     csv_file = database_filepath

--- a/test/test_fileCreationAndDataUpload.py
+++ b/test/test_fileCreationAndDataUpload.py
@@ -1,0 +1,38 @@
+import os
+import unittest
+from unittest.mock import patch
+from src.facematch.bulk_upload import upload_embedding_to_database
+
+class TestUploadEmbeddingToDatabase(unittest.TestCase):
+    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    def test_upload_embedding_to_database(self, mock_open):
+
+        # Sample data for testing
+        data = [
+            {"name": "Alice", "age": 30, "city": "New York"},
+            {"name": "Bob", "age": 25, "city": "San Francisco"}
+        ]
+
+        # Call the function to test
+        upload_embedding_to_database(data)
+
+        # Assert that open was called with the correct file path and mode
+        mock_open.assert_called_once_with("data/embeddings.csv", mode='w', newline='')
+
+        # Get the handle to the mock file
+        handle = mock_open()
+
+        # Get the written content
+        written_content = handle.write.call_args_list
+        
+        # Extracting the arguments to verify content written
+        written_lines = [args[0][0] for args in written_content]
+
+        # Assert that the header and data are written correctly
+        self.assertIn("name,age,city\r\n", written_lines)
+        self.assertIn("Alice,30,New York\r\n", written_lines)
+        self.assertIn("Bob,25,San Francisco\r\n", written_lines)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_fileCreationAndDataUpload.py
+++ b/test/test_fileCreationAndDataUpload.py
@@ -14,10 +14,10 @@ class TestUploadEmbeddingToDatabase(unittest.TestCase):
         ]
 
         # Call the function to test
-        upload_embedding_to_database(data)
+        upload_embedding_to_database(data, "data/test_embeddings.csv")
 
         # Assert that open was called with the correct file path and mode
-        mock_open.assert_called_once_with("data/embeddings.csv", mode='w', newline='')
+        mock_open.assert_called_once_with("data/test_embeddings.csv", mode='w', newline='')
 
         # Get the handle to the mock file
         handle = mock_open()
@@ -33,6 +33,24 @@ class TestUploadEmbeddingToDatabase(unittest.TestCase):
         self.assertIn("Alice,30,New York\r\n", written_lines)
         self.assertIn("Bob,25,San Francisco\r\n", written_lines)
 
+    def test_directory_creation(self):
+        # Test to ensure the directory is created
+        csv_file = "data/test_embeddings.csv"
+        
+        # Remove the directory if it exists for the test
+        if os.path.exists(csv_file):
+            os.remove(csv_file)
+
+        # Call the function
+        data = [{"name": "Test", "age": 0, "city": "Test City"}]
+        upload_embedding_to_database(data, csv_file)
+
+        # Assert that the directory now exists
+        self.assertTrue(os.path.exists(csv_file))
+
+        # Cleanup
+        if os.path.exists(csv_file):
+            os.remove(csv_file)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a feature to add new images to the database. This involves adding each image along with bounding boxes of all faces detected and corresponding face embeddings into a database.

Implemented `upload_embedding_to_database` function:

- The function takes in as input a list of dictionaries, where each dictionary represents one face's details (image path, bounding box information, face embedding).
- Each item is stored as a row in the csv file.

Wrote unit tests to test this functionality.

GitHub issue: https://github.com/RigvedManoj/FaceMatch/issues/9#issue-2589642853


Edit: Also includes addition of github workflow as per https://github.com/RigvedManoj/FaceMatch/issues/11#issue-2590037028