### PR TITLE
Integrate FAISS with find face functionality

### DIFF
--- a/resources/model_config.json
+++ b/resources/model_config.json
@@ -1,5 +1,5 @@
 {
   "model_name": "ArcFace",
   "detector_backend": "yolov8",
-  "threshold": 0.68
+  "threshold": 17
 }

--- a/src/facematch/FAISS.py
+++ b/src/facematch/FAISS.py
@@ -13,7 +13,7 @@ def add_embeddings_faiss_index(embeddings, database_filepath):
     if not os.path.exists(faiss_path):
         os.makedirs(os.path.dirname(faiss_path), exist_ok=True)
         # Create faiss index
-        index = faiss.IndexFlatIP(embeddings.shape[1])
+        index = faiss.IndexFlatL2(embeddings.shape[1])
     else:
         # Load the faiss index
         index = faiss.read_index(faiss_path)

--- a/src/facematch/interface.py
+++ b/src/facematch/interface.py
@@ -4,7 +4,7 @@ import os
 from src.facematch.database_functions import upload_embedding_to_database
 from src.facematch.face_representation import detect_faces_and_get_embeddings
 from src.facematch.resource_path import get_resource_path
-from src.facematch.similarity_search import cosine_similarity_search
+from src.facematch.similarity_search import euclidean_distance_search_faiss
 
 
 class FaceMatchModel:
@@ -44,8 +44,8 @@ class FaceMatchModel:
                 embedding_outputs = detect_faces_and_get_embeddings(image_file_path)
                 matching_image_paths = []
                 for embedding_output in embedding_outputs:
-                    output = cosine_similarity_search(
-                        embedding_output["embedding"], database_path, threshold=0.6
+                    output = euclidean_distance_search_faiss(
+                        embedding_output["embedding"], database_path, threshold=17
                     )
                     matching_image_paths.extend(output)
                 return matching_image_paths

--- a/src/facematch/similarity_search.py
+++ b/src/facematch/similarity_search.py
@@ -66,7 +66,9 @@ def cosine_similarity_search_faiss(
 
     return top_img_paths
 
-def euclidean_distance_search_faiss(query_vector, database_filepath, top_n=None, threshold=None
+
+def euclidean_distance_search_faiss(
+    query_vector, database_filepath, top_n=None, threshold=None
 ):
     # Ensure at least one of top_n or threshold is set
     if top_n is None and threshold is None:
@@ -82,7 +84,7 @@ def euclidean_distance_search_faiss(query_vector, database_filepath, top_n=None,
 
     if top_n:
         distances, indices = index.search(query_vector, top_n)
-        indices = indices[0][indices[0]!=-1]
+        indices = indices[0][indices[0] != -1]
     else:
         # Perform a Range Search
         radius = threshold  # adjust this value to control the search radius

--- a/test/test_similaritySearch.py
+++ b/test/test_similaritySearch.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from src.facematch.database_functions import upload_embedding_to_database
 from src.facematch.similarity_search import (cosine_similarity_search,
-                                             cosine_similarity_search_faiss)
+                                             euclidean_distance_search_faiss)
 
 
 class TestCosineSimilarity(unittest.TestCase):
@@ -88,7 +88,7 @@ class TestCosineSimilarityFAISS(unittest.TestCase):
 
     def test_cosine_similarity_top_n(self):
         # Test with top_n parameter
-        top_img_paths = cosine_similarity_search_faiss(
+        top_img_paths = euclidean_distance_search_faiss(
             self.query_vector, self.csv_file, top_n=2
         )
 
@@ -98,8 +98,8 @@ class TestCosineSimilarityFAISS(unittest.TestCase):
 
     def test_cosine_similarity_threshold(self):
         # Test with threshold parameter
-        top_img_paths = cosine_similarity_search_faiss(
-            self.query_vector, self.csv_file, threshold=0.95
+        top_img_paths = euclidean_distance_search_faiss(
+            self.query_vector, self.csv_file, threshold=17
         )
 
         # Assert that the correct image paths are returned based on the threshold
@@ -109,7 +109,7 @@ class TestCosineSimilarityFAISS(unittest.TestCase):
     def test_invalid_parameters(self):
         # Test with no top_n or threshold provided
         with self.assertRaises(ValueError):
-            cosine_similarity_search_faiss(self.query_vector, self.csv_file)
+            euclidean_distance_search_faiss(self.query_vector, self.csv_file)
 
     def tearDown(self):
         # Clean up the temporary CSV file


### PR DESCRIPTION
Integrated FAISS with the find face functionality that lets the user find the any matches for the person in an image in the large database. 

Changes during integration:
1. The faiss index range search function that allows us to find the faces that are close to the queried face within a radius, does not support cosine similarity. Hence, FAISS indexing was changed from **IndexFlatIP** (inner product for cosine similarity) **to** **IndexFlatL2** (euclidean distance). 

2. A new function to perform range search with Euclidean distance called `euclidean_distance_search_faiss` was implemented. 

3. The **threshold used** for the 'ArcFace'-'yolov8' model was updated to **17**. This value is arrived at after noticing that the distances returned from range search between two test images were squared values of the distances returned by the deepface library. Hence, the threshold value suggested by deepface library for the model combination (4.17) was also squared.

Github issue: https://github.com/RigvedManoj/FaceMatch/issues/20#issue-2616262227
 