### PR TITLE
Face confidence

### DIFF
--- a/resources/model_config.json
+++ b/resources/model_config.json
@@ -2,5 +2,6 @@
   "model_name": "ArcFace",
   "detector_backend": "yolov8",
   "euclidian-threshold": 17,
-  "cosine-threshold": 0.32
+  "cosine-threshold": 0.32,
+  "face_confidence_threshold": 0.7
 }

--- a/src/facematch/FAISS.py
+++ b/src/facematch/FAISS.py
@@ -1,6 +1,7 @@
 import os
 
 import faiss
+import numpy as np
 
 
 def add_embeddings_faiss_index(embeddings, database_filepath):
@@ -9,6 +10,10 @@ def add_embeddings_faiss_index(embeddings, database_filepath):
     """
     # Create a new path with the ".bin" extension
     faiss_path = database_filepath.replace(".csv", ".bin")
+
+    # Normalize the embeddings
+    embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
+    embeddings = embeddings.astype("float32")
 
     if not os.path.exists(faiss_path):
         os.makedirs(os.path.dirname(faiss_path), exist_ok=True)

--- a/src/facematch/face_representation.py
+++ b/src/facematch/face_representation.py
@@ -3,7 +3,9 @@ from deepface import DeepFace
 
 # Function that takes in path to image and returns a status field and a list of face embeddings and corresponding
 # region for all faces in the image.
-def detect_faces_and_get_embeddings(image_path, model_name, detector_backend):
+def detect_faces_and_get_embeddings(
+    image_path, model_name, detector_backend, face_confidence_threshold=0
+):
     try:
         results = DeepFace.represent(
             image_path,
@@ -11,9 +13,14 @@ def detect_faces_and_get_embeddings(image_path, model_name, detector_backend):
             detector_backend=detector_backend,
             enforce_detection=True,
         )
+
+        # Check if each face has a high enough confidence score
         face_embeddings = []
 
         for i, result in enumerate(results):
+            if result["face_confidence"] < face_confidence_threshold:
+                continue
+
             embedding = result["embedding"]
 
             x, y, width, height = (
@@ -31,6 +38,9 @@ def detect_faces_and_get_embeddings(image_path, model_name, detector_backend):
                 }
             )
 
+        # Return False, [] if no faces are above confidence threshold, else return True and the list of face embeddings
+        if len(face_embeddings) == 0:
+            return False, []
         return True, face_embeddings
     except Exception as e:
         return False, [e]

--- a/src/facematch/interface.py
+++ b/src/facematch/interface.py
@@ -26,6 +26,7 @@ class FaceMatchModel:
                 config = json.load(config_file)
             model_name = config["model_name"]
             detector_backend = config["detector_backend"]
+            face_confidence_threshold = config["face_confidence_threshold"]
 
             # Call helper functions for each image file.
             total_files_uploaded = 0
@@ -37,7 +38,10 @@ class FaceMatchModel:
                         (".png", ".jpg", ".jpeg", ".gif", ".bmp")
                     ):
                         status, value = detect_faces_and_get_embeddings(
-                            image_path, model_name, detector_backend
+                            image_path,
+                            model_name,
+                            detector_backend,
+                            face_confidence_threshold,
                         )
                         if status:
                             total_files_uploaded += 1
@@ -92,12 +96,16 @@ class FaceMatchModel:
             model_name = config["model_name"]
             detector_backend = config["detector_backend"]
             threshold = config["cosine-threshold"]
+            face_confidence_threshold = config["face_confidence_threshold"]
 
             # Call helper functions to get similar images.
             filename = os.path.basename(image_file_path)
             if filename.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp")):
                 status, embedding_outputs = detect_faces_and_get_embeddings(
-                    image_file_path, model_name, detector_backend
+                    image_file_path,
+                    model_name,
+                    detector_backend,
+                    face_confidence_threshold,
                 )
                 matching_image_paths = []
                 if status:


### PR DESCRIPTION
Add face confidence metric used by DeepFace to filter out unidentifiable faces such as hidden or extremely blurred faces.

1. Only faces above confidence threshold are now uploaded to database.
2. Only faces above confidence threshold are used to find matching images during querying.

Closes #38 

Additional changes:
Corrected FAISS.py to normalize vectors before creating faiss index.

